### PR TITLE
User roles

### DIFF
--- a/prisma/migrations/20210818121331_roles/migration.sql
+++ b/prisma/migrations/20210818121331_roles/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('ADMIN', 'SUPPORTER', 'ALPHA', 'BETA', 'BASIC');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "role" "Role" NOT NULL DEFAULT E'BASIC';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,8 +17,17 @@ model User {
   name      String?
   devices   Device[]
   palettes  Palette[]
+  role      Role      @default(BASIC)
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
+}
+
+enum Role {
+  ADMIN
+  SUPPORTER
+  ALPHA
+  BETA
+  BASIC
 }
 
 //* Device

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import { PrismaClient } from '@prisma/client';
 import { Context as ApolloContext } from 'apollo-server-core';
+import { registerEnumType } from 'type-graphql';
 
 export interface Context extends ApolloContext {
   prisma: PrismaClient;
@@ -76,3 +77,16 @@ export interface NanoleafColorResponse {
   saturation: number;
   brightness: number;
 }
+
+//* User
+export enum RoleEnum {
+  ADMIN = 'ADMIN',
+  SUPPORTER = 'SUPPORTER',
+  ALPHA = 'ALPHA',
+  BETA = 'BETA',
+  BASIC = 'BASIC',
+}
+
+registerEnumType(RoleEnum, {
+  name: 'RoleEnum',
+});

--- a/src/user/User.ts
+++ b/src/user/User.ts
@@ -1,4 +1,7 @@
+import { Role } from '@prisma/client';
 import { ObjectType, Field, ID } from 'type-graphql';
+
+import { RoleEnum } from 'types';
 
 @ObjectType()
 class User {
@@ -10,6 +13,9 @@ class User {
 
   @Field(() => String, { nullable: true })
   name: string | null;
+
+  @Field(() => RoleEnum)
+  role: Role;
 }
 
 export default User;

--- a/src/user/UserInputs.ts
+++ b/src/user/UserInputs.ts
@@ -1,4 +1,7 @@
+import { Role } from '.prisma/client';
 import { Field, InputType } from 'type-graphql';
+
+import { RoleEnum } from 'types';
 
 @InputType()
 class CreateUserInput {
@@ -13,6 +16,9 @@ class CreateUserInput {
 class UpdateUserInput {
   @Field(() => String, { nullable: true })
   name?: string | null;
+
+  @Field(() => RoleEnum, { nullable: true })
+  role?: Role;
 }
 
 export { CreateUserInput, UpdateUserInput };


### PR DESCRIPTION
# User Roles

## Issues

- Resolves #4 

---

## Description

Adds `Role` to the Prisma schema on `User` and updates all user-related queries/muations.

---

## Changes

- Adds `Role` enum to Prisma schema and sets a default role of `BASIC` to `User`
- Updates `updateUser` to accept a `role` parameter
- Updates `User` type defs to have `role` where necessary
- Creates `RoleEnum` TS Type in order to play nice with TypeGraphQL

---

## Screenshots

> Example query from Apollo Studio
<img width="1678" alt="image" src="https://user-images.githubusercontent.com/24458700/129902608-884fb444-08a4-4ae6-bc0c-ac86f0a70a76.png">

---

## Sanity Checks

- [x] All tests are passing
- [x] There are no linting errors
- [x] There are no build errors
