### PR TITLE
Access Keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@prisma/client": "^2.29.1",
+    "@sendgrid/mail": "^7.4.6",
     "@types/graphql-fields": "^1.3.3",
     "apollo-server": "^2.25.2",
     "class-validator": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/graphql-fields": "^1.3.3",
     "apollo-server": "^2.25.2",
     "class-validator": "^0.13.1",
+    "dayjs": "^1.10.6",
     "dotenv": "^10.0.0",
     "graphql-fields": "^2.0.3",
     "graphql-scalars": "^1.10.0",

--- a/prisma/migrations/20210821213217_access_key/migration.sql
+++ b/prisma/migrations/20210821213217_access_key/migration.sql
@@ -1,0 +1,30 @@
+/*
+  Warnings:
+
+  - Added the required column `invitedById` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "invitedById" TEXT NOT NULL,
+ADD COLUMN     "invites" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateTable
+CREATE TABLE "AccessKey" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expireAt" TIMESTAMP(3) NOT NULL,
+
+    PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AccessKey.key_unique" ON "AccessKey"("key");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AccessKey.email_unique" ON "AccessKey"("email");
+
+-- AddForeignKey
+ALTER TABLE "User" ADD FOREIGN KEY ("invitedById") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20210821224132_invited_by_optional/migration.sql
+++ b/prisma/migrations/20210821224132_invited_by_optional/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - Made the column `name` on table `User` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "name" SET NOT NULL,
+ALTER COLUMN "invitedById" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,16 +10,30 @@ generator client {
   provider = "prisma-client-js"
 }
 
+//* Access Keys
+model AccessKey {
+  id        String   @id @default(uuid())
+  key       String   @unique @default(uuid())
+  userId    String
+  email     String   @unique
+  createdAt DateTime @default(now())
+  expireAt  DateTime
+}
+
 //* User
 model User {
-  id        String    @id @default(uuid())
-  email     String    @unique
-  name      String?
-  devices   Device[]
-  palettes  Palette[]
-  role      Role      @default(BASIC)
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @updatedAt
+  id                String    @id @default(uuid())
+  email             String    @unique
+  name              String?
+  devices           Device[]
+  palettes          Palette[]
+  role              Role      @default(BASIC)
+  invites           Int       @default(0)
+  invitedById       String
+  invitedBy         User      @relation(fields: [invitedById], references: [id])
+  invitedUserToUser User[]    @relation("UserToUser")
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
 }
 
 enum Role {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,13 +24,13 @@ model AccessKey {
 model User {
   id                String    @id @default(uuid())
   email             String    @unique
-  name              String?
+  name              String
   devices           Device[]
   palettes          Palette[]
   role              Role      @default(BASIC)
   invites           Int       @default(0)
-  invitedById       String
-  invitedBy         User      @relation(fields: [invitedById], references: [id])
+  invitedById       String?
+  invitedBy         User?     @relation(fields: [invitedById], references: [id])
   invitedUserToUser User[]    @relation("UserToUser")
   createdAt         DateTime  @default(now())
   updatedAt         DateTime  @updatedAt

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,23 @@
+import { PrismaClient } from '@prisma/client';
+const prisma = new PrismaClient();
+
+async function main() {
+  const admin = await prisma.user.create({
+    data: {
+      email: 'hartigan.hm@gmail.com',
+      name: 'Hugh Hartigan',
+      role: 'ADMIN',
+    },
+  });
+
+  console.log(admin);
+}
+
+main()
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/accessKey/AccessKey.ts
+++ b/src/accessKey/AccessKey.ts
@@ -1,0 +1,18 @@
+import { Field, ID, ObjectType } from 'type-graphql';
+
+@ObjectType()
+class AccessKey {
+  @Field(() => ID)
+  id: string;
+
+  @Field()
+  key: string;
+
+  @Field()
+  email: string;
+
+  @Field()
+  userId: string;
+}
+
+export default AccessKey;

--- a/src/accessKey/AccessKeyResolver.ts
+++ b/src/accessKey/AccessKeyResolver.ts
@@ -7,15 +7,15 @@ import { Context, RoleEnum } from 'types';
 import { User } from 'user';
 import { errors as userErrors } from 'user/definitions';
 import AccessKey from './AccessKey';
-import { constants, errors } from './definitions';
+import { constants } from './definitions';
 import { validateNewAccessKey } from './utilities';
 
 const { SENDGRID_INVITE_TEMPLATE_ID, WAVEZ_FROM_EMAIL } = constants;
 
 @Resolver(AccessKey)
 class AccessKeyResolver {
-  @Directive('@authenticated')
   @Directive(`@authorized(role: ${RoleEnum.ADMIN})`)
+  @Directive('@authenticated')
   @Mutation(() => AccessKey)
   async createAccessKey(
     @Arg('email') email: string,
@@ -42,23 +42,19 @@ class AccessKeyResolver {
     }
   }
 
-  @Directive('@authenticated')
   @Directive(`@authorized(role: ${RoleEnum.ADMIN})`)
-  @Mutation(() => AccessKey)
+  @Directive('@authenticated')
+  @Mutation(() => Boolean)
   async deleteAccessKeyById(
     @Arg('id') id: string,
     @Ctx() { prisma }: Context
-  ): Promise<string> {
+  ): Promise<boolean> {
     try {
-      const accessKey = await prisma.accessKey.delete({
+      await prisma.accessKey.delete({
         where: { id },
       });
 
-      if (!accessKey) {
-        throw new UserInputError(JSON.stringify(errors.notFound));
-      }
-
-      return id;
+      return true;
     } catch (error) {
       console.error(error);
 
@@ -66,8 +62,8 @@ class AccessKeyResolver {
     }
   }
 
-  @Directive('@authenticated')
   @Directive(`@authorized(role: ${RoleEnum.SUPPORTER})`)
+  @Directive('@authenticated')
   @Mutation(() => Boolean)
   async inviteByEmail(
     @Arg('email') email: string,

--- a/src/accessKey/AccessKeyResolver.ts
+++ b/src/accessKey/AccessKeyResolver.ts
@@ -1,0 +1,37 @@
+import { Arg, Ctx, Directive, Mutation, Resolver } from 'type-graphql';
+import dayjs from 'dayjs';
+
+import { Context, RoleEnum } from 'types';
+import AccessKey from './AccessKey';
+import { User } from 'user';
+
+@Resolver(AccessKey)
+class AccessKeyResolver {
+  @Directive('@authenticated')
+  @Directive(`@authorized(role: ${RoleEnum.SUPPORTER})`)
+  @Mutation(() => AccessKey)
+  async createAccessKey(
+    @Arg('email') email: string,
+    @Ctx() { prisma, user }: Context
+  ): Promise<AccessKey> {
+    try {
+      const expireAt = dayjs().add(3, 'day').toISOString();
+
+      const accessKey = await prisma.accessKey.create({
+        data: {
+          email,
+          expireAt,
+          userId: (user as User).id,
+        },
+      });
+
+      return accessKey;
+    } catch (error) {
+      console.error(error);
+
+      throw error;
+    }
+  }
+}
+
+export default AccessKeyResolver;

--- a/src/accessKey/AccessKeyResolver.ts
+++ b/src/accessKey/AccessKeyResolver.ts
@@ -10,7 +10,7 @@ import AccessKey from './AccessKey';
 import { constants, copy, errors } from './definitions';
 import { validateNewAccessKey } from './utilities';
 
-const { SENDGRID_INVITE_TEMPLATE_ID, WAVEZ_FROM_EMAIL } = constants;
+const { SENDGRID_INVITE_TEMPLATE_ID } = constants;
 const { descriptions } = copy;
 
 @Resolver(AccessKey)
@@ -131,7 +131,7 @@ class AccessKeyResolver {
       //* Build SG email message
       const message: MailDataRequired = {
         to: email,
-        from: WAVEZ_FROM_EMAIL,
+        from: process.env.WAVEZ_FROM_EMAIL,
         templateId: SENDGRID_INVITE_TEMPLATE_ID,
         dynamicTemplateData: {
           accessKey: accessKey.key,

--- a/src/accessKey/AccessKeyResolver.ts
+++ b/src/accessKey/AccessKeyResolver.ts
@@ -155,6 +155,7 @@ class AccessKeyResolver {
 
       return true;
     } catch (error) {
+      // TODO: Update error handling to delete access key if SG fails
       console.error(error);
 
       throw error;

--- a/src/accessKey/AccessKeyResolver.ts
+++ b/src/accessKey/AccessKeyResolver.ts
@@ -7,14 +7,15 @@ import { Context, RoleEnum } from 'types';
 import { User } from 'user';
 import { errors as userErrors } from 'user/definitions';
 import AccessKey from './AccessKey';
-import { constants, errors } from './definitions';
+import { constants, copy, errors } from './definitions';
 import { validateNewAccessKey } from './utilities';
 
 const { SENDGRID_INVITE_TEMPLATE_ID, WAVEZ_FROM_EMAIL } = constants;
+const { descriptions } = copy;
 
 @Resolver(AccessKey)
 class AccessKeyResolver {
-  @Query(() => Boolean)
+  @Query(() => Boolean, { description: descriptions.findAccessKeyByEmail })
   async findAccessKeyByEmail(
     @Arg('email') email: string,
     @Ctx() { prisma }: Context
@@ -52,7 +53,7 @@ class AccessKeyResolver {
 
   @Directive(`@authorized(role: ${RoleEnum.ADMIN})`)
   @Directive('@authenticated')
-  @Mutation(() => AccessKey)
+  @Mutation(() => AccessKey, { description: descriptions.createAccessKey })
   async createAccessKey(
     @Arg('email') email: string,
     @Ctx() { prisma, user }: Context
@@ -80,7 +81,7 @@ class AccessKeyResolver {
 
   @Directive(`@authorized(role: ${RoleEnum.ADMIN})`)
   @Directive('@authenticated')
-  @Mutation(() => Boolean)
+  @Mutation(() => Boolean, { description: descriptions.deleteAccessKeyById })
   async deleteAccessKeyById(
     @Arg('id') id: string,
     @Ctx() { prisma }: Context
@@ -100,7 +101,7 @@ class AccessKeyResolver {
 
   @Directive(`@authorized(role: ${RoleEnum.SUPPORTER})`)
   @Directive('@authenticated')
-  @Mutation(() => Boolean)
+  @Mutation(() => Boolean, { description: descriptions.inviteByEmail })
   async inviteByEmail(
     @Arg('email') email: string,
     @Ctx() { prisma, user }: Context

--- a/src/accessKey/AccessKeyResolver.ts
+++ b/src/accessKey/AccessKeyResolver.ts
@@ -1,9 +1,11 @@
+import { UserInputError } from 'apollo-server';
 import { Arg, Ctx, Directive, Mutation, Resolver } from 'type-graphql';
 import dayjs from 'dayjs';
 
 import { Context, RoleEnum } from 'types';
-import AccessKey from './AccessKey';
 import { User } from 'user';
+import AccessKey from './AccessKey';
+import { errors } from './definitions';
 
 @Resolver(AccessKey)
 class AccessKeyResolver {
@@ -26,6 +28,30 @@ class AccessKeyResolver {
       });
 
       return accessKey;
+    } catch (error) {
+      console.error(error);
+
+      throw error;
+    }
+  }
+
+  @Directive('@authenticated')
+  @Directive(`@authorized(role: ${RoleEnum.ADMIN})`)
+  @Mutation(() => AccessKey)
+  async deleteAccessKeyById(
+    @Arg('id') id: string,
+    @Ctx() { prisma }: Context
+  ): Promise<string> {
+    try {
+      const accessKey = await prisma.accessKey.delete({
+        where: { id },
+      });
+
+      if (!accessKey) {
+        throw new UserInputError(JSON.stringify(errors.notFound));
+      }
+
+      return id;
     } catch (error) {
       console.error(error);
 

--- a/src/accessKey/definitions/constants.ts
+++ b/src/accessKey/definitions/constants.ts
@@ -1,5 +1,5 @@
-const SENDGRID_INVITE_TEMPLATE_ID = 'd-63646556b97d4b70a7a6c669d296ad31';
-const WAVEZ_FROM_EMAIL = 'info@wavez.dev';
+const SENDGRID_INVITE_TEMPLATE_ID = 'd-c07016d7475f434aa9923c43087a4b4a';
+const WAVEZ_FROM_EMAIL = 'Hartigan.HM@gmail.com';
 
 const constants = {
   SENDGRID_INVITE_TEMPLATE_ID,

--- a/src/accessKey/definitions/constants.ts
+++ b/src/accessKey/definitions/constants.ts
@@ -1,9 +1,7 @@
 const SENDGRID_INVITE_TEMPLATE_ID = 'd-c07016d7475f434aa9923c43087a4b4a';
-const WAVEZ_FROM_EMAIL = 'info@wavez.dev';
 
 const constants = {
   SENDGRID_INVITE_TEMPLATE_ID,
-  WAVEZ_FROM_EMAIL,
 };
 
 export default constants;

--- a/src/accessKey/definitions/constants.ts
+++ b/src/accessKey/definitions/constants.ts
@@ -1,5 +1,5 @@
 const SENDGRID_INVITE_TEMPLATE_ID = 'd-c07016d7475f434aa9923c43087a4b4a';
-const WAVEZ_FROM_EMAIL = 'info@wavez.com';
+const WAVEZ_FROM_EMAIL = 'info@wavez.dev';
 
 const constants = {
   SENDGRID_INVITE_TEMPLATE_ID,

--- a/src/accessKey/definitions/constants.ts
+++ b/src/accessKey/definitions/constants.ts
@@ -1,5 +1,5 @@
 const SENDGRID_INVITE_TEMPLATE_ID = 'd-c07016d7475f434aa9923c43087a4b4a';
-const WAVEZ_FROM_EMAIL = 'Hartigan.HM@gmail.com';
+const WAVEZ_FROM_EMAIL = 'info@wavez.com';
 
 const constants = {
   SENDGRID_INVITE_TEMPLATE_ID,

--- a/src/accessKey/definitions/constants.ts
+++ b/src/accessKey/definitions/constants.ts
@@ -1,0 +1,9 @@
+const SENDGRID_INVITE_TEMPLATE_ID = 'd-63646556b97d4b70a7a6c669d296ad31';
+const WAVEZ_FROM_EMAIL = 'info@wavez.dev';
+
+const constants = {
+  SENDGRID_INVITE_TEMPLATE_ID,
+  WAVEZ_FROM_EMAIL,
+};
+
+export default constants;

--- a/src/accessKey/definitions/copy.ts
+++ b/src/accessKey/definitions/copy.ts
@@ -1,0 +1,12 @@
+const descriptions = {
+  createAccessKey: '(ADMIN) Creates a new access key with a given email',
+  deleteAccessKeyById: '(ADMIN) Deletes an access key by a given ID',
+  findAccessKeyByEmail:
+    'Returns true if an access key by a given email is found. Used when someone attempts to login to the client via Auth0, but does not have an existing account.',
+  inviteByEmail:
+    '(SUPPORTER) If the given user has invites available, creates a new access key and sends an invite to the given email.',
+};
+
+const copy = { descriptions };
+
+export default copy;

--- a/src/accessKey/definitions/errors.ts
+++ b/src/accessKey/definitions/errors.ts
@@ -1,10 +1,21 @@
 import { ErrorResponse } from 'types';
 
 const errors: Record<string, ErrorResponse> = {
+  expired: {
+    status: 400,
+    message: 'Access key expired',
+    friendlyMessage:
+      'This access key is expired. Please reach out to the person who invited you for assistance.',
+  },
   notFound: {
     status: 404,
     message: 'Access key does not exists',
     friendlyMessage: 'This access key does not exist or has already been used.',
+  },
+  wrongEmail: {
+    status: 400,
+    message: 'Wrong email provided',
+    friendlyMessage: 'Incorrect email provided with access key',
   },
 };
 

--- a/src/accessKey/definitions/errors.ts
+++ b/src/accessKey/definitions/errors.ts
@@ -17,6 +17,12 @@ const errors: Record<string, ErrorResponse> = {
     message: 'Wrong email provided',
     friendlyMessage: 'Incorrect email provided with access key',
   },
+  alreadyExists: {
+    status: 400,
+    message: 'Email already has an access key',
+    friendlyMessage:
+      'An access key has already been sent to this email address',
+  },
 };
 
 export default errors;

--- a/src/accessKey/definitions/errors.ts
+++ b/src/accessKey/definitions/errors.ts
@@ -1,0 +1,11 @@
+import { ErrorResponse } from 'types';
+
+const errors: Record<string, ErrorResponse> = {
+  notFound: {
+    status: 404,
+    message: 'Access key does not exists',
+    friendlyMessage: 'This access key does not exist or has already been used.',
+  },
+};
+
+export default errors;

--- a/src/accessKey/definitions/index.ts
+++ b/src/accessKey/definitions/index.ts
@@ -1,0 +1,3 @@
+import errors from './errors';
+
+export { errors };

--- a/src/accessKey/definitions/index.ts
+++ b/src/accessKey/definitions/index.ts
@@ -1,4 +1,5 @@
 import constants from './constants';
+import copy from './copy';
 import errors from './errors';
 
-export { constants, errors };
+export { constants, copy, errors };

--- a/src/accessKey/definitions/index.ts
+++ b/src/accessKey/definitions/index.ts
@@ -1,3 +1,4 @@
+import constants from './constants';
 import errors from './errors';
 
-export { errors };
+export { constants, errors };

--- a/src/accessKey/index.ts
+++ b/src/accessKey/index.ts
@@ -1,0 +1,4 @@
+import AccessKey from './AccessKey';
+import AccessKeyResolver from './AccessKeyResolver';
+
+export { AccessKey, AccessKeyResolver };

--- a/src/accessKey/utilities/index.ts
+++ b/src/accessKey/utilities/index.ts
@@ -1,0 +1,3 @@
+import validateNewAccessKey from './validateNewAccessKey';
+
+export { validateNewAccessKey };

--- a/src/accessKey/utilities/validateNewAccessKey.ts
+++ b/src/accessKey/utilities/validateNewAccessKey.ts
@@ -16,7 +16,7 @@ const validateNewAccessKey = async (
   });
 
   if (doesUserExist) {
-    throw new UserInputError(JSON.stringify(userErrors.userAlreadyExists));
+    throw new UserInputError(JSON.stringify(userErrors.alreadyExists));
   }
 
   //* Check is user has already been sent an access key

--- a/src/accessKey/utilities/validateNewAccessKey.ts
+++ b/src/accessKey/utilities/validateNewAccessKey.ts
@@ -1,0 +1,34 @@
+import { PrismaClient } from '@prisma/client';
+import { UserInputError } from 'apollo-server';
+
+import { errors as userErrors } from 'user/definitions';
+import { errors } from '../definitions';
+
+const validateNewAccessKey = async (
+  prisma: PrismaClient,
+  email: string
+): Promise<void> => {
+  //* Check if email is already used
+  const doesUserExist = await prisma.user.findUnique({
+    where: {
+      email,
+    },
+  });
+
+  if (doesUserExist) {
+    throw new UserInputError(JSON.stringify(userErrors.userAlreadyExists));
+  }
+
+  //* Check is user has already been sent an access key
+  const doesAccessKeyExistByEmail = await prisma.accessKey.findUnique({
+    where: {
+      email,
+    },
+  });
+
+  if (doesAccessKeyExistByEmail) {
+    throw new UserInputError(JSON.stringify(errors.alreadyExists));
+  }
+};
+
+export default validateNewAccessKey;

--- a/src/device/DeviceResolver.ts
+++ b/src/device/DeviceResolver.ts
@@ -18,8 +18,10 @@ import { Context, DeviceMacSubstringByType } from 'types';
 import { User } from 'user';
 import { updateCurrentState } from 'nanoleaf/utils';
 import { errors as userErrors } from 'user/definitions';
-import { errors as deviceErrors } from './definitions';
+import { copy, errors as deviceErrors } from './definitions';
 import { Device, WifiDevice } from './Device';
+
+const { descriptions } = copy;
 
 const findeDeviceByType = (device: WifiDevice, macSubstring: string) =>
   device.mac.toLocaleLowerCase().includes(macSubstring.toLocaleLowerCase());
@@ -86,7 +88,8 @@ class DeviceResolver {
     return user;
   }
 
-  @Query(() => [WifiDevice])
+  @Directive('authenticated')
+  @Query(() => [WifiDevice], { description: descriptions.discoverWifiDevices })
   async discoverWifiDevices(): Promise<WifiDevice[]> {
     try {
       const devices = await find();
@@ -99,7 +102,10 @@ class DeviceResolver {
     }
   }
 
-  @Query(() => [WifiDevice])
+  @Directive('authenticated')
+  @Query(() => [WifiDevice], {
+    description: descriptions.discoverWifiDevicesByType,
+  })
   async discoverWifiDevicesByType(
     @Arg('type') type: DeviceType
   ): Promise<WifiDevice[]> {
@@ -121,7 +127,7 @@ class DeviceResolver {
   }
 
   @Directive('@authenticated')
-  @Query(() => [Device])
+  @Query(() => [Device], { description: descriptions.getAllDevicesByUserId })
   async getAllDevicesByUserId(
     @Ctx() { prisma, user }: Context
   ): Promise<Prisma.Device[]> {
@@ -146,7 +152,10 @@ class DeviceResolver {
   }
 
   @Directive('@authenticated')
-  @Query(() => Device, { nullable: true })
+  @Query(() => Device, {
+    description: descriptions.getDeviceById,
+    nullable: true,
+  })
   async getDeviceById(
     @Arg('id') id: string,
     @Ctx() { prisma, user }: Context
@@ -177,11 +186,11 @@ class DeviceResolver {
   }
 
   @Directive('@authenticated')
-  @Mutation(() => String)
+  @Mutation(() => String, { description: descriptions.deleteDeviceById })
   async deleteDeviceById(
     @Arg('id') id: string,
     @Ctx() { prisma, user }: Context
-  ): Promise<string> {
+  ): Promise<boolean> {
     try {
       const device = await prisma.device.delete({
         where: {
@@ -199,7 +208,7 @@ class DeviceResolver {
         throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
       }
 
-      return id;
+      return true;
     } catch (error) {
       console.error(error);
 
@@ -208,7 +217,9 @@ class DeviceResolver {
   }
 
   @Directive('@authenticated')
-  @Mutation(() => Boolean)
+  @Mutation(() => Boolean, {
+    description: descriptions.updateAllDevicePowerByUserId,
+  })
   async updateAllDevicePowerByUserId(
     @Arg('isOn') isOn: boolean,
     @Ctx() { prisma, user }: Context
@@ -250,7 +261,7 @@ class DeviceResolver {
   }
 
   @Directive('@authenticated')
-  @Mutation(() => Boolean)
+  @Mutation(() => Boolean, { description: descriptions.updateDevicePowerById })
   async updateDevicePowerById(
     @Arg('id') id: string,
     @Arg('isOn') isOn: boolean,
@@ -295,7 +306,9 @@ class DeviceResolver {
   }
 
   @Directive('@authenticated')
-  @Mutation(() => Boolean)
+  @Mutation(() => Boolean, {
+    description: descriptions.updateDevicePowerByType,
+  })
   async updateDevicePowerByType(
     @Arg('type') type: DeviceType,
     @Arg('isOn') isOn: boolean,
@@ -340,7 +353,10 @@ class DeviceResolver {
   }
 
   @Directive('@authenticated')
-  @Mutation(() => Device, { nullable: true })
+  @Mutation(() => Device, {
+    description: descriptions.updateDeviceNameById,
+    nullable: true,
+  })
   async updateDeviceNameById(
     @Arg('id') id: string,
     @Arg('name') name: string,

--- a/src/device/DeviceResolver.ts
+++ b/src/device/DeviceResolver.ts
@@ -134,7 +134,7 @@ class DeviceResolver {
       });
 
       if (!devices.length) {
-        throw new UserInputError(JSON.stringify(userErrors.userNoDevices));
+        throw new UserInputError(JSON.stringify(userErrors.noDevices));
       }
 
       return devices;
@@ -165,7 +165,7 @@ class DeviceResolver {
       }
 
       if (device.userId !== user?.id) {
-        throw new ForbiddenError(JSON.stringify(userErrors.userNotAuthorized));
+        throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
       }
 
       return device;
@@ -196,7 +196,7 @@ class DeviceResolver {
       }
 
       if (device.userId !== user?.id) {
-        throw new ForbiddenError(JSON.stringify(userErrors.userNotAuthorized));
+        throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
       }
 
       return id;
@@ -220,11 +220,11 @@ class DeviceResolver {
       });
 
       if (!devices.length) {
-        throw new UserInputError(JSON.stringify(userErrors.userNoDevices));
+        throw new UserInputError(JSON.stringify(userErrors.noDevices));
       }
 
       if (devices[0].userId !== user?.id) {
-        throw new ForbiddenError(JSON.stringify(userErrors.userNotAuthorized));
+        throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
       }
 
       devices.forEach(async ({ id, ip, nanoleafAuthToken }) => {
@@ -269,7 +269,7 @@ class DeviceResolver {
       }
 
       if (device.userId !== user?.id) {
-        throw new ForbiddenError(JSON.stringify(userErrors.userNotAuthorized));
+        throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
       }
 
       if (!device.nanoleafAuthToken) {
@@ -314,7 +314,7 @@ class DeviceResolver {
       }
 
       if (devices[0].userId !== user?.id) {
-        throw new ForbiddenError(JSON.stringify(userErrors.userNotAuthorized));
+        throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
       }
 
       devices.forEach(async ({ id, ip, nanoleafAuthToken }) => {
@@ -360,7 +360,7 @@ class DeviceResolver {
       }
 
       if (foundDevice.userId !== user?.id) {
-        throw new ForbiddenError(JSON.stringify(userErrors.userNotAuthorized));
+        throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
       }
 
       const device = await prisma.device.update({

--- a/src/device/DeviceResolver.ts
+++ b/src/device/DeviceResolver.ts
@@ -186,7 +186,7 @@ class DeviceResolver {
   }
 
   @Directive('@authenticated')
-  @Mutation(() => String, { description: descriptions.deleteDeviceById })
+  @Mutation(() => Boolean, { description: descriptions.deleteDeviceById })
   async deleteDeviceById(
     @Arg('id') id: string,
     @Ctx() { prisma, user }: Context

--- a/src/device/definitions/copy.ts
+++ b/src/device/definitions/copy.ts
@@ -1,0 +1,24 @@
+const descriptions = {
+  discoverWifiDevices:
+    "Returns a list of local Wi-Fi devices on the user's local network",
+  discoverWifiDevicesByType:
+    "Returns a list of local Wi-Fi devices on the user's local network by type, filtering by a substring of the type's Mac Address",
+  getAllDevicesByUserId:
+    'Returns a list of registered devices that belong to the authenticated user',
+  getDeviceById:
+    'Returns a given device by ID that belongs to the authenticated user',
+  deleteDeviceById:
+    'Returns a boolean when a device by ID that belongs to the authenticated user is successfully deleted',
+  updateDeviceNameById:
+    'Updates the name of a given device by ID that belongs to the authenticated user',
+  updateAllDevicePowerByUserId:
+    'Updates the power state of all devices that belong to the authenticated user',
+  updateDevicePowerById:
+    'Updates the power state of a given device by ID that belongs to the authenticated user',
+  updateDevicePowerByType:
+    'Updates the power state of a given group of devices by that belong to the authenticated user',
+};
+
+const copy = { descriptions };
+
+export default copy;

--- a/src/device/definitions/index.ts
+++ b/src/device/definitions/index.ts
@@ -1,3 +1,4 @@
+import copy from './copy';
 import errors from './errors';
 
-export { errors };
+export { copy, errors };

--- a/src/directives/auth.ts
+++ b/src/directives/auth.ts
@@ -33,10 +33,10 @@ class AuthenticationDirective extends SchemaDirectiveVisitor {
     field.resolve = (
       root,
       args,
-      context,
+      context: Context,
       info
     ): GraphQLFieldResolver<typeof root, typeof context> => {
-      if (!(context as Context).user) {
+      if (!context.user) {
         // If the user isn't there throw an error
         throw new AuthenticationError(
           JSON.stringify(userErrors.notAuthenticated)

--- a/src/directives/auth.ts
+++ b/src/directives/auth.ts
@@ -39,7 +39,7 @@ class AuthenticationDirective extends SchemaDirectiveVisitor {
       if (!(context as Context).user) {
         // If the user isn't there throw an error
         throw new AuthenticationError(
-          JSON.stringify(userErrors.userNotAuthenticated)
+          JSON.stringify(userErrors.notAuthenticated)
         );
       }
 
@@ -72,7 +72,7 @@ class AuthorizationDirective extends SchemaDirectiveVisitor {
 
       if (userRoleHierarcy < authorizationHierarchy) {
         // If user.role isn't there throw an error
-        throw new ForbiddenError(JSON.stringify(userErrors.userNotAuthorized));
+        throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
       }
 
       return resolve(root, args, context, info) as GraphQLFieldResolver<

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -5,6 +5,7 @@ declare global {
       SENDGRID_API_KEY: string;
       NODE_ENV: 'development' | 'production';
       PORT?: string;
+      WAVEZ_FROM_EMAIL: string;
     }
   }
 }

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -2,6 +2,7 @@ declare global {
   namespace NodeJS {
     interface ProcessEnv {
       SECRET: string;
+      SENDGRID_API_KEY: string;
       NODE_ENV: 'development' | 'production';
       PORT?: string;
     }

--- a/src/nanoleaf/authToken/NanoleafAuthTokenResolver.ts
+++ b/src/nanoleaf/authToken/NanoleafAuthTokenResolver.ts
@@ -13,7 +13,7 @@ import { Device } from 'device';
 import { Context } from 'types';
 import { getPaletteSyncConfig } from 'palettes/utils';
 import { User } from 'user';
-import { errors } from '../definitions';
+import { copy, errors } from '../definitions';
 import NanoleafAuthToken from './NanoleafAuthToken';
 import { AuthenticateNewUserInput } from '../NanoleafInputs';
 import {
@@ -21,6 +21,8 @@ import {
   doesDeviceExistsByIpAddress,
   getAllPanelProperties,
 } from '../utils';
+
+const { descriptions } = copy;
 
 @Resolver(NanoleafAuthToken)
 class NanoleafAuthTokenResolver {
@@ -39,7 +41,9 @@ class NanoleafAuthTokenResolver {
   }
 
   @Directive('@authenticated')
-  @Mutation(() => String)
+  @Mutation(() => String, {
+    description: descriptions.authenticateWithDeviceByUserId,
+  })
   async authenticateWithDeviceByUserId(
     @Ctx() { prisma, user }: Context,
     @Arg('input') input: AuthenticateNewUserInput,
@@ -106,11 +110,13 @@ class NanoleafAuthTokenResolver {
   }
 
   @Directive('@authenticated')
-  @Mutation(() => String)
+  @Mutation(() => Boolean, {
+    description: descriptions.deleteNanoleafAuthToken,
+  })
   async deleteNanoleafAuthToken(
     @Arg('id') id: string,
     @Ctx() { prisma }: Context
-  ): Promise<string> {
+  ): Promise<boolean> {
     try {
       const nanoleafAuthToken = await prisma.nanoleafAuthToken.delete({
         where: { id },
@@ -120,7 +126,7 @@ class NanoleafAuthTokenResolver {
         throw new UserInputError(JSON.stringify(errors.authTokenNotFound(id)));
       }
 
-      return id;
+      return true;
     } catch (error) {
       console.error(error);
 

--- a/src/nanoleaf/definitions/copy.ts
+++ b/src/nanoleaf/definitions/copy.ts
@@ -1,0 +1,9 @@
+const descriptions = {
+  authenticateWithDeviceByUserId:
+    'Authenticates a user with a given Nanoleaf device by IP Address that is on their local network by creating a new NanoleafAuthToken, new Device, and, optionally, new Palettes associated with the Nanoleaf device',
+  deleteNanoleafAuthToken: 'Deletes a given NanoleafAuthToken by ID',
+};
+
+const copy = { descriptions };
+
+export default copy;

--- a/src/nanoleaf/definitions/copy.ts
+++ b/src/nanoleaf/definitions/copy.ts
@@ -2,6 +2,10 @@ const descriptions = {
   authenticateWithDeviceByUserId:
     'Authenticates a user with a given Nanoleaf device by IP Address that is on their local network by creating a new NanoleafAuthToken, new Device, and, optionally, new Palettes associated with the Nanoleaf device',
   deleteNanoleafAuthToken: 'Deletes a given NanoleafAuthToken by ID',
+  updateCurrentStateAll:
+    'Updates the current state (on, brightness, hue, sat, ct, colorMode) of a all Nanoleaf devices that belong to the authenticated user',
+  updateCurrentStateByDeviceId:
+    'Updates the current state (on, brightness, hue, sat, ct, colorMode) of a given Nanoleaf device by ID that belongs to the authenticated user',
 };
 
 const copy = { descriptions };

--- a/src/nanoleaf/definitions/index.ts
+++ b/src/nanoleaf/definitions/index.ts
@@ -1,4 +1,5 @@
 import constants from './constants';
+import copy from './copy';
 import errors from './errors';
 
-export { constants, errors };
+export { constants, copy, errors };

--- a/src/nanoleaf/state/NanoleafStateResolver.ts
+++ b/src/nanoleaf/state/NanoleafStateResolver.ts
@@ -61,7 +61,7 @@ class NanoleafStateResolver {
       });
 
       if (!devices.length) {
-        throw new UserInputError(JSON.stringify(userErrors.userNoDevices));
+        throw new UserInputError(JSON.stringify(userErrors.noDevices));
       }
 
       devices.forEach(async ({ ip, nanoleafAuthToken }) => {

--- a/src/nanoleaf/state/NanoleafStateResolver.ts
+++ b/src/nanoleaf/state/NanoleafStateResolver.ts
@@ -2,17 +2,22 @@ import { UserInputError } from 'apollo-server-errors';
 import { Arg, Ctx, Directive, Mutation, Resolver } from 'type-graphql';
 
 import { Context } from 'types';
+import { User } from 'user';
 import { NanoleafStateInput } from 'nanoleaf/NanoleafInputs';
 import { updateCurrentState } from 'nanoleaf/utils';
 import { errors as deviceErrors } from 'device/definitions';
 import { errors as userErrors } from 'user/definitions';
 import { NanoleafState } from './NanoleafState';
-import { User } from 'user';
+import { copy } from '../definitions';
+
+const { descriptions } = copy;
 
 @Resolver(NanoleafState)
 class NanoleafStateResolver {
   @Directive('@authenticated')
-  @Mutation(() => Boolean)
+  @Mutation(() => Boolean, {
+    description: descriptions.updateCurrentStateByDeviceId,
+  })
   async updateCurrentStateByDeviceId(
     @Arg('deviceId') deviceId: string,
     @Arg('stateInput') stateInput: NanoleafStateInput,
@@ -49,7 +54,7 @@ class NanoleafStateResolver {
   }
 
   @Directive('@authenticated')
-  @Mutation(() => Boolean)
+  @Mutation(() => Boolean, { description: descriptions.updateCurrentStateAll })
   async updateCurrentStateAll(
     @Arg('stateInput') stateInput: NanoleafStateInput,
     @Ctx() { prisma, user }: Context

--- a/src/palettes/PaletteResolver.ts
+++ b/src/palettes/PaletteResolver.ts
@@ -94,7 +94,7 @@ class PaletteResolver {
     }
 
     if (palette.userId !== user?.id) {
-      throw new ForbiddenError(JSON.stringify(userErrors.userNotAuthorized));
+      throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
     }
 
     return palette;
@@ -145,7 +145,7 @@ class PaletteResolver {
     }
 
     if (palette.userId !== user?.id) {
-      throw new ForbiddenError(JSON.stringify(userErrors.userNotAuthorized));
+      throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
     }
 
     await prisma.palette.delete({
@@ -174,7 +174,7 @@ class PaletteResolver {
       }
 
       if (palette?.userId !== user?.id) {
-        throw new ForbiddenError(JSON.stringify(userErrors.userNotAuthorized));
+        throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
       }
 
       //* Grab all devices
@@ -188,11 +188,11 @@ class PaletteResolver {
       });
 
       if (!devices.length) {
-        throw new UserInputError(JSON.stringify(userErrors.userNoDevices));
+        throw new UserInputError(JSON.stringify(userErrors.noDevices));
       }
 
       if (devices[0].userId !== user?.id) {
-        throw new ForbiddenError(JSON.stringify(userErrors.userNotAuthorized));
+        throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
       }
 
       //* Make update calls to Nanoleaf devices
@@ -241,7 +241,7 @@ class PaletteResolver {
       }
 
       if (palette.userId !== user?.id) {
-        throw new ForbiddenError(JSON.stringify(userErrors.userNotAuthorized));
+        throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
       }
 
       //* Grab all devices
@@ -261,7 +261,7 @@ class PaletteResolver {
       }
 
       if (device.userId !== user?.id) {
-        throw new ForbiddenError(JSON.stringify(userErrors.userNotAuthorized));
+        throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
       }
 
       //* Handle errors for auth token
@@ -305,7 +305,7 @@ class PaletteResolver {
       }
 
       if (palette.userId !== user?.id) {
-        throw new ForbiddenError(JSON.stringify(userErrors.userNotAuthorized));
+        throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
       }
 
       //* Grab all devices
@@ -380,7 +380,7 @@ class PaletteResolver {
       }
 
       if (device.userId !== user?.id) {
-        throw new ForbiddenError(JSON.stringify(userErrors.userNotAuthorized));
+        throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
       }
 
       const {
@@ -444,7 +444,7 @@ class PaletteResolver {
       }
 
       if (palette.userId !== user?.id) {
-        throw new ForbiddenError(JSON.stringify(userErrors.userNotAuthorized));
+        throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
       }
 
       if (input.shouldUpdateDevices) {
@@ -463,7 +463,7 @@ class PaletteResolver {
 
             if (userId !== user?.id) {
               throw new ForbiddenError(
-                JSON.stringify(userErrors.userNotAuthorized)
+                JSON.stringify(userErrors.notAuthorized)
               );
             }
 
@@ -522,7 +522,7 @@ class PaletteResolver {
       }
 
       if (palette.userId !== user?.id) {
-        throw new ForbiddenError(JSON.stringify(userErrors.userNotAuthorized));
+        throw new ForbiddenError(JSON.stringify(userErrors.notAuthorized));
       }
 
       if (!palette.devices.length) {
@@ -541,7 +541,7 @@ class PaletteResolver {
 
             if (userId !== user?.id) {
               throw new ForbiddenError(
-                JSON.stringify(userErrors.userNotAuthorized)
+                JSON.stringify(userErrors.notAuthorized)
               );
             }
 

--- a/src/palettes/PaletteResolver.ts
+++ b/src/palettes/PaletteResolver.ts
@@ -29,7 +29,9 @@ import {
   UpdatePaletteNameInput,
 } from './PaletteInputs';
 import { getPaletteSyncConfig, validateColorJson } from './utils';
-import { errors } from './definitions';
+import { copy, errors } from './definitions';
+
+const { descriptions } = copy;
 
 @Resolver(Palette)
 class PaletteResolver {
@@ -64,7 +66,7 @@ class PaletteResolver {
   }
 
   @Directive('@authenticated')
-  @Query(() => [Palette])
+  @Query(() => [Palette], { description: descriptions.getAllPalettesByUserId })
   async getAllPalettesByUserId(
     @Ctx() { prisma, user }: Context
   ): Promise<Palette[]> {
@@ -78,7 +80,10 @@ class PaletteResolver {
   }
 
   @Directive('@authenticated')
-  @Query(() => Palette, { nullable: true })
+  @Query(() => Palette, {
+    description: descriptions.getPaletteById,
+    nullable: true,
+  })
   async getPaletteById(
     @Arg('id') id: string,
     @Ctx() { prisma, user }: Context
@@ -100,8 +105,9 @@ class PaletteResolver {
     return palette;
   }
 
+  // TODO: Update to create with Nanoleaf
   @Directive('@authenticated')
-  @Mutation(() => Palette)
+  @Mutation(() => Palette, { description: descriptions.createPalette })
   async createPalette(
     @Arg('input') input: CreatePaletteInput,
     @Ctx() { prisma, user }: Context
@@ -128,8 +134,9 @@ class PaletteResolver {
     }
   }
 
+  // TODO: Update to create with Nanoleaf
   @Directive('@authenticated')
-  @Mutation(() => String)
+  @Mutation(() => String, { description: descriptions.deletePaletteById })
   async deletePaletteById(
     @Arg('id') id: string,
     @Ctx() { prisma, user }: Context
@@ -155,9 +162,13 @@ class PaletteResolver {
     return id;
   }
 
+  // TODO: Update to sync with other device types
+  //* Note: Only syncs with Nanoleaf currently
   @Directive('@authenticated')
-  @Mutation(() => Boolean)
-  async setPaletteToAllDevicesByUserId(
+  @Mutation(() => Boolean, {
+    description: descriptions.setPaletteToAllDevices,
+  })
+  async setPaletteToAllDevices(
     @Arg('id') id: string,
     @Ctx() { prisma, user }: Context
   ): Promise<boolean> {
@@ -223,7 +234,7 @@ class PaletteResolver {
   }
 
   @Directive('@authenticated')
-  @Mutation(() => Boolean)
+  @Mutation(() => Boolean, { description: descriptions.setPaletteToDeviceById })
   async setPaletteToDeviceById(
     @Arg('input') input: SetPaletteByDeviceIdInput,
     @Ctx() { prisma, user }: Context
@@ -287,7 +298,9 @@ class PaletteResolver {
   }
 
   @Directive('@authenticated')
-  @Mutation(() => Boolean)
+  @Mutation(() => Boolean, {
+    description: descriptions.setPaletteToDeviceByType,
+  })
   async setPaletteToDeviceByType(
     @Arg('input') input: SetPaletteByDeviceType,
     @Ctx() { prisma, user }: Context
@@ -351,8 +364,11 @@ class PaletteResolver {
     }
   }
 
+  // TODO: Update to sync with other device types
   @Directive('@authenticated')
-  @Mutation(() => [Palette])
+  @Mutation(() => [Palette], {
+    description: descriptions.syncPalettesByDeviceId,
+  })
   async syncPalettesByDeviceId(
     @Arg('deviceId') deviceId: string,
     @Ctx() { prisma, user }: Context
@@ -419,7 +435,7 @@ class PaletteResolver {
   }
 
   @Directive('@authenticated')
-  @Mutation(() => Palette)
+  @Mutation(() => Palette, { description: descriptions.updatePaletteNameById })
   async updatePaletteNameById(
     @Arg('input') input: UpdatePaletteNameInput,
     @Ctx() { prisma, user }: Context
@@ -497,7 +513,9 @@ class PaletteResolver {
   }
 
   @Directive('@authenticated')
-  @Mutation(() => Palette)
+  @Mutation(() => Palette, {
+    description: descriptions.updatePaletteColorsById,
+  })
   async updatePaletteColorsById(
     @Arg('input') input: UpdatePaletteColorsInput,
     @Ctx() { prisma, user }: Context

--- a/src/palettes/definitions/copy.ts
+++ b/src/palettes/definitions/copy.ts
@@ -1,0 +1,26 @@
+const descriptions = {
+  createPalette:
+    'Creates a Palette that belongs to the authenticated user (Does not sync with external APIs)',
+  deletePaletteById:
+    'Deletes a given Palette by ID that belongs to the authenticated user (Does not sync with external APIs)',
+  getAllPalettesByUserId:
+    'Returns all Pallettes that belong to the authenticated user',
+  getPaletteById:
+    'Returns a given Pallette by ID that belongs to the authenticated user',
+  setPaletteToAllDevices:
+    'Sets a given Palette by ID to all Devices that belong to the authenticated user (Currently only works with Nanoleaf)',
+  setPaletteToDeviceById:
+    'Sets a given Palette by ID to a given Device by ID that belongs to the authenticated user (Currently only works with Nanoleaf)',
+  setPaletteToDeviceByType:
+    'Sets a given Pallette by ID to a group of Devices by type that belong to the authenticated user (Currently only works with Nanoleaf)',
+  syncPalettesByDeviceId:
+    'Fetch and save all Palettes by a given Device ID to the database. Any existing Palettes will be updated and any new Palettes will be created. External APIs are considered a source of truth and any differences in the application database will be overwritten (Currently only works with Nanoleaf).',
+  updatePaletteColorsById:
+    "Updates a given Palette's colors by ID. Optionally syncs with external APIs based on any associated Devices (Currently only works with Nanoleaf).",
+  updatePaletteNameById:
+    "Updates a give Palette's name by ID. Optionally syncs with external APIs based on any associated Devices (Currently only works with Nanoleaf)",
+};
+
+const copy = { descriptions };
+
+export default copy;

--- a/src/palettes/definitions/index.ts
+++ b/src/palettes/definitions/index.ts
@@ -1,3 +1,4 @@
+import copy from './copy';
 import errors from './errors';
 
-export { errors };
+export { copy, errors };

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import dotenv from 'dotenv';
 import { buildSchemaSync } from 'type-graphql';
 
 import { Context } from 'types';
+import { AccessKeyResolver } from 'accessKey';
 import { DeviceResolver } from 'device';
 import { AuthenticationDirective, AuthorizationDirective } from 'directives';
 import { NanoleafAuthTokenResolver, NanoleafStateResolver } from 'nanoleaf';
@@ -20,6 +21,7 @@ const prisma = new PrismaClient();
 const schema = buildSchemaSync({
   // emitSchemaFile: true,
   resolvers: [
+    AccessKeyResolver,
     DeviceResolver,
     NanoleafAuthTokenResolver,
     NanoleafStateResolver,

--- a/src/user/User.ts
+++ b/src/user/User.ts
@@ -11,11 +11,14 @@ class User {
   @Field()
   email: string;
 
-  @Field(() => String, { nullable: true })
-  name: string | null;
+  @Field()
+  name: string;
 
   @Field(() => RoleEnum)
   role: Role;
+
+  @Field()
+  invites: number;
 }
 
 @ObjectType()

--- a/src/user/UserInputs.ts
+++ b/src/user/UserInputs.ts
@@ -1,5 +1,5 @@
 import { Role } from '.prisma/client';
-import { Field, InputType } from 'type-graphql';
+import { Field, ID, InputType } from 'type-graphql';
 
 import { RoleEnum } from 'types';
 

--- a/src/user/UserInputs.ts
+++ b/src/user/UserInputs.ts
@@ -1,5 +1,5 @@
 import { Role } from '.prisma/client';
-import { Field, InputType } from 'type-graphql';
+import { Field, InputType, Int } from 'type-graphql';
 
 import { RoleEnum } from 'types';
 
@@ -22,6 +22,9 @@ class UpdateUserInput {
 
   @Field(() => RoleEnum, { nullable: true })
   role?: Role;
+
+  @Field(() => Number, { nullable: true })
+  invites?: number;
 }
 
 export { CreateUserInput, UpdateUserInput };

--- a/src/user/UserInputs.ts
+++ b/src/user/UserInputs.ts
@@ -22,9 +22,21 @@ class UpdateUserInput {
 
   @Field(() => RoleEnum, { nullable: true })
   role?: Role;
+}
+
+@InputType()
+class UpdateUserAdminInput {
+  @Field(() => ID)
+  id: string;
+
+  @Field(() => String, { nullable: true })
+  name?: string;
+
+  @Field(() => RoleEnum, { nullable: true })
+  role?: Role;
 
   @Field(() => Number, { nullable: true })
   invites?: number;
 }
 
-export { CreateUserInput, UpdateUserInput };
+export { CreateUserInput, UpdateUserInput, UpdateUserAdminInput };

--- a/src/user/UserInputs.ts
+++ b/src/user/UserInputs.ts
@@ -6,10 +6,13 @@ import { RoleEnum } from 'types';
 @InputType()
 class CreateUserInput {
   @Field()
+  accessKey: string;
+
+  @Field()
   email: string;
 
-  @Field(() => String, { nullable: true })
-  name?: string | null;
+  @Field()
+  name: string;
 }
 
 @InputType()

--- a/src/user/UserInputs.ts
+++ b/src/user/UserInputs.ts
@@ -1,5 +1,5 @@
 import { Role } from '.prisma/client';
-import { Field, InputType, Int } from 'type-graphql';
+import { Field, InputType } from 'type-graphql';
 
 import { RoleEnum } from 'types';
 

--- a/src/user/UserInputs.ts
+++ b/src/user/UserInputs.ts
@@ -18,7 +18,7 @@ class CreateUserInput {
 @InputType()
 class UpdateUserInput {
   @Field(() => String, { nullable: true })
-  name?: string | null;
+  name?: string;
 
   @Field(() => RoleEnum, { nullable: true })
   role?: Role;

--- a/src/user/UserResolver.ts
+++ b/src/user/UserResolver.ts
@@ -14,7 +14,11 @@ import { Device } from 'device';
 import { Context, RoleEnum } from 'types';
 import { errors as accessKeyErrors } from 'accessKey/definitions';
 import { SignInResponse, User } from './User';
-import { CreateUserInput, UpdateUserInput } from './UserInputs';
+import {
+  CreateUserInput,
+  UpdateUserAdminInput,
+  UpdateUserInput,
+} from './UserInputs';
 import { Palette } from 'palettes';
 import { UserInputError } from 'apollo-server';
 import { errors } from './definitions';
@@ -181,9 +185,32 @@ class UserResolver {
     @Ctx() { prisma, user }: Context
   ): Promise<User> {
     try {
-      const updatedUser = prisma.user.update({
+      const updatedUser = await prisma.user.update({
         where: {
           id: (user as User).id,
+        },
+        data: input,
+      });
+
+      return updatedUser;
+    } catch (error) {
+      console.error(error);
+
+      throw error;
+    }
+  }
+
+  @Directive(`@authorized(role: ${RoleEnum.ADMIN})`)
+  @Directive('@authenticated')
+  @Mutation(() => User)
+  async updateUserById(
+    @Arg('input') input: UpdateUserAdminInput,
+    @Ctx() { prisma }: Context
+  ): Promise<User> {
+    try {
+      const updatedUser = await prisma.user.update({
+        where: {
+          id: input.id,
         },
         data: input,
       });

--- a/src/user/UserResolver.ts
+++ b/src/user/UserResolver.ts
@@ -53,8 +53,8 @@ class UserResolver {
     return palettes;
   }
 
-  @Directive('@authenticated')
   @Directive(`@authorized(role: ${RoleEnum.ADMIN})`)
+  @Directive('@authenticated')
   @Query(() => [User])
   async getAllUsers(@Ctx() { prisma }: Context): Promise<User[]> {
     try {

--- a/src/user/UserResolver.ts
+++ b/src/user/UserResolver.ts
@@ -21,7 +21,9 @@ import {
 } from './UserInputs';
 import { Palette } from 'palettes';
 import { UserInputError } from 'apollo-server';
-import { errors } from './definitions';
+import { copy, errors } from './definitions';
+
+const { descriptions } = copy;
 
 @Resolver(User)
 class UserResolver {
@@ -59,7 +61,7 @@ class UserResolver {
 
   @Directive(`@authorized(role: ${RoleEnum.ADMIN})`)
   @Directive('@authenticated')
-  @Query(() => [User])
+  @Query(() => [User], { description: descriptions.getAllUsers })
   async getAllUsers(@Ctx() { prisma }: Context): Promise<User[]> {
     try {
       const users = await prisma.user.findMany();
@@ -73,12 +75,12 @@ class UserResolver {
   }
 
   @Directive('@authenticated')
-  @Query(() => User)
+  @Query(() => User, { description: descriptions.getCurrentUser })
   getCurrentUser(@Ctx() { user }: Context): User {
     return user as User;
   }
 
-  @Mutation(() => SignInResponse)
+  @Mutation(() => SignInResponse, { description: descriptions.signUp })
   async signUp(
     @Arg('input') input: CreateUserInput,
     @Ctx() { createToken, prisma }: Context
@@ -152,7 +154,7 @@ class UserResolver {
     }
   }
 
-  @Mutation(() => SignInResponse)
+  @Mutation(() => SignInResponse, { description: descriptions.signIn })
   async signIn(
     @Arg('email') email: string,
     @Ctx() { createToken, prisma }: Context
@@ -179,7 +181,7 @@ class UserResolver {
   }
 
   @Directive('@authenticated')
-  @Mutation(() => User)
+  @Mutation(() => User, { description: descriptions.updateUser })
   async updateUser(
     @Arg('input') input: UpdateUserInput,
     @Ctx() { prisma, user }: Context
@@ -202,7 +204,7 @@ class UserResolver {
 
   @Directive(`@authorized(role: ${RoleEnum.ADMIN})`)
   @Directive('@authenticated')
-  @Mutation(() => User)
+  @Mutation(() => User, { description: descriptions.updateUserById })
   async updateUserById(
     @Arg('input') input: UpdateUserAdminInput,
     @Ctx() { prisma }: Context

--- a/src/user/UserResolver.ts
+++ b/src/user/UserResolver.ts
@@ -88,7 +88,7 @@ class UserResolver {
       });
 
       if (doesUserExist) {
-        throw new UserInputError(JSON.stringify(errors.userAlreadyExists));
+        throw new UserInputError(JSON.stringify(errors.alreadyExists));
       }
 
       //* Check if access key exists
@@ -161,7 +161,7 @@ class UserResolver {
       });
 
       if (!user) {
-        throw new UserInputError(JSON.stringify(errors.userNotFound));
+        throw new UserInputError(JSON.stringify(errors.notFound));
       }
 
       const token = createToken(user);

--- a/src/user/definitions/copy.ts
+++ b/src/user/definitions/copy.ts
@@ -1,0 +1,14 @@
+const descriptions = {
+  getAllUsers: '(ADMIN) Returns a list of all users',
+  getCurrentUser: 'Returns the currently authenticated user',
+  signIn: 'Returns the currently authenticated user and a new JWT',
+  signUp:
+    'Returns a newly created user and JWT. Requires an existing, valid access key associated with a given email.',
+  updateUser:
+    'Updates non-restricted properties on the currently authenticated user',
+  updateUserById: '(ADMIN) Updates a given user by ID',
+};
+
+const copy = { descriptions };
+
+export default copy;

--- a/src/user/definitions/errors.ts
+++ b/src/user/definitions/errors.ts
@@ -1,31 +1,39 @@
-const errors = {
-  userAlreadyExists: {
+import { ErrorResponse } from 'types';
+
+const errors: Record<string, ErrorResponse> = {
+  alreadyExists: {
     status: 400,
     message: 'User by email already exists',
     friendlyMessage:
       'This user already exists. Please sign-in with your existing credentials',
   },
-  userNotAuthenticated: {
+  notAuthenticated: {
     status: 400,
     message: 'User not authenticated',
     friendlyMessage: 'User not authenticated. Please sign in.',
   },
-  userNotAuthorized: {
+  notAuthorized: {
     status: 401,
     message: 'User not authorized',
     friendlyMessage:
       'User not authorized to access this resource. Please try again.',
   },
-  userNotFound: {
+  notFound: {
     status: 404,
     message: 'User does not exist',
     friendlyMessage: "We can't find that user. Please try again.",
   },
-  userNoDevices: {
+  noDevices: {
     status: 404,
     message: 'User has no associated devices',
     friendlyMessage:
       "We can't find any devices that belong to that user. Please try again.",
+  },
+  noInvites: {
+    status: 400,
+    message: 'User has no invites',
+    friendlyMessage:
+      'You have no invites left. If you would like more, please contact us.',
   },
 };
 

--- a/src/user/definitions/index.ts
+++ b/src/user/definitions/index.ts
@@ -1,3 +1,4 @@
+import copy from './copy';
 import errors from './errors';
 
-export { errors };
+export { copy, errors };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
     "skipLibCheck": true
   },
   "exclude": ["node_modules"],
-  "include": ["./src/**/*.ts"],
+  "include": ["./src/**/*.ts", "./prisma/**/*.ts"],
   "ts-node": {
     "files": true,
     "require": ["tsconfig-paths/register"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1030,6 +1030,11 @@ cssfilter@0.0.10:
   resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
   integrity sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=
 
+dayjs@^1.10.6:
+  version "1.10.6"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.6.tgz#288b2aa82f2d8418a6c9d4df5898c0737ad02a63"
+  integrity sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw==
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -204,6 +204,29 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
+"@sendgrid/client@^7.4.6":
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/@sendgrid/client/-/client-7.4.6.tgz#c7b5a6fc0c12e48fcc77faf183f0a99f5cc8ec52"
+  integrity sha512-g3vjDyN1hDTKwPe9THGNuf4HKkx+cC3dSOM7SM88Pg6Q9SRI+GDGzsdnGRfFFpsdHBVVrHCSk0n2f4YZVCv4zA==
+  dependencies:
+    "@sendgrid/helpers" "^7.4.6"
+    axios "^0.21.1"
+
+"@sendgrid/helpers@^7.4.6":
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/@sendgrid/helpers/-/helpers-7.4.6.tgz#0fed40aeb9738a0d698ec2ce311c73f7460cfd72"
+  integrity sha512-Vvt4d60fkU/DPSwMyxXtlnbw4/B+5Y9eeYnygTxhmw8TNzUhdPphr7SaRSperWJ8P1VeQZzobvQNyMj5E7A3UA==
+  dependencies:
+    deepmerge "^4.2.2"
+
+"@sendgrid/mail@^7.4.6":
+  version "7.4.6"
+  resolved "https://registry.yarnpkg.com/@sendgrid/mail/-/mail-7.4.6.tgz#497e59ac415bf19561293c1fe92c5ef86eee7fae"
+  integrity sha512-1HTW5Iu1oKw5r8cltAPfVFbaJjjIrWmYR8WP0I8br01ImUhy1/42vGCVl6QWkPP6pcAfsWNIrjSPx20ZcVNvVQ==
+  dependencies:
+    "@sendgrid/client" "^7.4.6"
+    "@sendgrid/helpers" "^7.4.6"
+
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.8.tgz#c1e4e80d6f964fbecb3359c43bd48b40f7cadad9"
@@ -808,6 +831,13 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 backo2@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
@@ -1053,6 +1083,11 @@ deep-is@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
 define-properties@^1.1.3:
   version "1.1.3"
@@ -1462,6 +1497,11 @@ flatted@^3.1.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.2.tgz#64bfed5cb68fe3ca78b3eb214ad97b63bedce561"
   integrity sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==
+
+follow-redirects@^1.10.0:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.2.tgz#cecb825047c00f5e66b142f90fed4f515dec789b"
+  integrity sha512-yLR6WaE2lbF0x4K2qE2p9PEXKLDjUjnR/xmjS3wHAYxtlsI9MLLBJUZirAHKzUZDGLxje7w/cXR49WOUo4rbsA==
 
 for-each@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION
# Access Keys

## Issues

- Resolves #5 
- Resolves #9 

---

## Description

Adds a concept of invites and access keys for new and existing users. Existing users can send invites to new users (if they have an allotment of invites). New users will receive an email invite with an access key (associated with their email address) that will be required to sign up.

---

## Changes

### Access Keys

**Queries**

- `findAccessKeyByEmail`: Returns `boolean`; no restrictions

**Mutations**

- `createAccessKey`: Returns `AccessKey`; restricted to `ADMIN`
- `deleteAccessKeyById`: Returns `boolean`; restricted to `ADMIN`
- `inviteByEmail`: Returns `boolean`; restricted to `SUPPORTER`

### Misc

- Adds seed data for an initial user
- Adds descriptions to all resolvers
- Refactors naming convention of all `errors`
- Updates `signIn/signUp` mutations to return `SignInResponse` with `{ token, user }`

---

## Fixes

- Updates misuse of `Context` in miscellaneous files
- Updates `Directives` to have correct order (authentication before autheorization)

---

## Screenshots

> Example invite email
<img width="424" alt="image" src="https://user-images.githubusercontent.com/24458700/131231966-a29652f1-8389-4fc4-8b92-a0668b779efe.png">


---

## Sanity Checks

- [x] All tests are passing
- [x] There are no linting errors
- [x] There are no build errors
